### PR TITLE
Cowboy req corruption

### DIFF
--- a/include/sheep.hrl
+++ b/include/sheep.hrl
@@ -11,7 +11,7 @@
 -record(sheep_response, {
     status_code = 500 :: http_code(),
     headers = [] :: list(),
-    body = <<>> :: map() | binary()
+    body = <<>> :: map() | binary() | undefined
 }).
 
 -record(sheep_options, {

--- a/src/sheep_http.erl
+++ b/src/sheep_http.erl
@@ -50,7 +50,7 @@ upgrade(CowRequest, Env, Handler, HandlerOpts) ->
                     true -> Handler:sheep_init(Request, HandlerOpts);
                     false -> {#sheep_options{}, []}
                 end,
-            case decode_payload(Request, Options0) of
+            case decode_payload(Handler, Request, Options0) of
                 {ok, Request2} ->
                     Response0 = handle(Request2, Handler, Options0, State),
                     {Options0, Response0};
@@ -63,8 +63,8 @@ upgrade(CowRequest, Env, Handler, HandlerOpts) ->
     #sheep_response{
         status_code = ResponseCode,
         headers = ResponseHeaders,
-        body = Body
-    } = encode_payload(Request, Response, Options),
+        body = ResponseBody
+    } = encode_payload(Handler, Request, Response, Options),
 
     {ok, CowResponse} = cowboy_req:reply(ResponseCode, ResponseHeaders, ResponseBody, CowRequest5),
     log_query(CowResponse, ResponseCode),
@@ -85,10 +85,11 @@ get_header(Name, #sheep_request{headers = Headers}, Default) ->
 
 %%% Inner functions
 
--spec decode_payload(#sheep_request{}, #sheep_options{}) -> {ok, #sheep_request{}} | {error, #sheep_response{}}.
-decode_payload(#sheep_request{body = <<>>} = Request, _Options) ->
+-spec decode_payload(module(), #sheep_request{}, #sheep_options{}) ->
+                            {ok, #sheep_request{}} | {error, #sheep_response{}}.
+decode_payload(_, #sheep_request{body = <<>>} = Request, _Options) ->
     {ok, Request};
-decode_payload(#sheep_request{body = Body} = Request, Options) ->
+decode_payload(Handler, #sheep_request{body = Body} = Request, Options) ->
     RawContentType = get_header(<<"content-type">>, Request),
     CleanContentType = clean_content_type(RawContentType),
     DecodeSpec = decode_spec(Options),
@@ -108,25 +109,29 @@ decode_payload(#sheep_request{body = Body} = Request, Options) ->
                         {stacktrace, ST}
                     ]),
                     E = <<"Can't decode '", RawContentType/binary, "' payload">>,
-                    {error, #sheep_response{status_code = 400, body = E}}
+                    {error, handle_internal_error(
+                              Handler, Request, {request_decode_error, Class, Reason, RawContentType},
+                              #sheep_response{status_code = 400, body = E})}
             end;
         error ->
             error_logger:info_report([
                 {error, "not supported"},
                 {<<"content-type">>, RawContentType}
             ]),
-            {error, #sheep_response{status_code = 415, body = <<"Not supported 'content-type'">>}}
+            {error, handle_internal_error(
+                      Handler, Request, {unsupported_content_type, RawContentType},
+                      #sheep_response{status_code = 415, body = <<"Not supported 'content-type'">>})}
     end.
 
 
--spec encode_payload(#sheep_request{}, #sheep_response{}, #sheep_options{}) -> #sheep_response{}.
-encode_payload(_Request, #sheep_response{body = Body} = Response, _Options) when is_binary(Body) ->
+-spec encode_payload(module(), #sheep_request{}, #sheep_response{}, #sheep_options{}) -> #sheep_response{}.
+encode_payload(_Handler, _Request, #sheep_response{body = Body} = Response, _Options) when is_binary(Body) ->
     Response;
-encode_payload(_Request, #sheep_response{status_code = 204} = Response, _Options) ->
+encode_payload(_Handler, _Request, #sheep_response{status_code = 204} = Response, _Options) ->
     Response#sheep_response{body = <<>>};
-encode_payload(_Request, #sheep_response{body = undefined} = Response, _Options) ->
+encode_payload(_Handler, _Request, #sheep_response{body = undefined} = Response, _Options) ->
     Response#sheep_response{body = <<>>};
-encode_payload(Request, #sheep_response{body = Body, headers = Headers} = Response, Options) ->
+encode_payload(Handler, Request, #sheep_response{body = Body, headers = Headers} = Response, Options) ->
     AcceptContentType = get_header(<<"accept">>, Request),
     EncodeSpec = encode_spec(Options),
 
@@ -152,14 +157,18 @@ encode_payload(Request, #sheep_response{body = Body, headers = Headers} = Respon
                         {stacktrace, ST}
                     ]),
                     E = <<"Can't encode '", AcceptContentType/binary, "' payload">>,
-                    #sheep_response{status_code = 500, body = E}
+                    handle_internal_error(
+                      Handler, Request, {response_encode_error, Class, Reason, AcceptContentType},
+                      #sheep_response{status_code = 500, body = E})
             end;
         error ->
             error_logger:info_report([
                 {error, "not acceptable"},
                 {<<"content-type">>, AcceptContentType}
             ]),
-            #sheep_response{status_code = 406, body = <<"Not acceptable">>}
+            handle_internal_error(
+              Handler, Request, {unsupported_accept, AcceptContentType},
+              sheep_response:new_406())
     end.
 
 
@@ -170,7 +179,7 @@ handle(#sheep_request{method = Method} = Request, HandlerModule, Options, State)
         {ok, Handlers} when is_list(Handlers) ->
             call_handlers(Handlers, Request, HandlerModule, State);
         error ->
-            sheep_response:new_405()
+            handle_internal_error(HandlerModule, Request, method_not_allowed, sheep_response:new_405())
     end.
 
 
@@ -184,7 +193,10 @@ call_handlers([Handler | Handlers], Request, Module, State) ->
         _ ->
             case erlang:function_exported(Module, Handler, 2) of
                 true -> call_fun(fun Module:Handler/2, Handlers, Request, Module, State);
-                _ -> sheep_response:new_501()
+                _ ->
+                    handle_internal_error(
+                      Module, Request, {handler_callback_missing, Module, Handler},
+                      sheep_response:new_501())
             end
     end.
 
@@ -225,6 +237,27 @@ handle_exception(Handler, Request, Class, Reason) ->
                 {stacktrace, ST2}
             ]),
             sheep_response:new_500()
+    end.
+
+
+handle_internal_error(Handler, Request, Reason, Default) ->
+    case erlang:function_exported(Handler, exception_handler, 3) of
+        true ->
+            try
+                Handler:exception_handler(Request, sheep_internal_error, Reason)
+            catch
+                Class1:Reason1 ->
+                    ST1 = erlang:get_stacktrace(),
+                    error_logger:error_report([
+                        {error, invalid_exception_handler},
+                        {handler, Handler},
+                        {exception, {Class1, Reason1}},
+                        {stacktrace, ST1}
+                    ]),
+                    Default
+            end;
+        false ->
+            Default
     end.
 
 

--- a/src/sheep_http.erl
+++ b/src/sheep_http.erl
@@ -116,6 +116,8 @@ encode_payload(_Request, #sheep_response{body = Body} = Response, _Options) when
     Response;
 encode_payload(_Request, #sheep_response{status_code = 204} = Response, _Options) ->
     Response#sheep_response{body = <<>>};
+encode_payload(_Request, #sheep_response{body = undefined} = Response, _Options) ->
+    Response#sheep_response{body = <<>>};
 encode_payload(Request, #sheep_response{body = Body, headers = Headers} = Response, Options) ->
     AcceptContentType = get_header(<<"accept">>, Request),
     EncodeSpec = encode_spec(Options),

--- a/test/sheep_http_SUITE_data/internal_error_handler.erl
+++ b/test/sheep_http_SUITE_data/internal_error_handler.erl
@@ -1,0 +1,46 @@
+-module(internal_error_handler).
+-behaviour(sheep_http).
+
+-export([init/3, create/2, exception_handler/3]).
+
+-include("sheep.hrl").
+
+-spec init(atom(), cowboy_req:req(), term()) -> tuple().
+init(_Transport, Req, _Opts) ->
+    {upgrade, protocol, sheep_http, Req, []}.
+
+
+create(#sheep_request{bindings = #{<<"type">> := <<"response_encode_error">>}}, _State)->
+    Body = #{<<"error">> => self()},
+    #sheep_response{status_code = 200, body = Body};
+create(_, _) ->
+    #sheep_response{status_code = 200, body = #{}}.
+
+
+
+
+
+exception_handler(_Request, sheep_internal_error, Details) ->
+    {Code, Body} = handle_internal_error(Details),
+    #sheep_response{status_code = Code, body = jiffy:encode(Body)}.
+
+handle_internal_error({request_decode_error = T, Class, _Reason, RawContentType}) ->
+    {400, #{type => T,
+            class => Class,
+            content_type => RawContentType}};
+handle_internal_error({unsupported_content_type = T, RawContentType}) ->
+    {415, #{type => T,
+            content_type => RawContentType}};
+handle_internal_error({response_encode_error  =T, Class, _Reason, AcceptContentType}) ->
+    {500, #{type => T,
+            class => Class,
+            content_type => AcceptContentType}};
+handle_internal_error({unsupported_accept = T, AcceptContentType}) ->
+    {406, #{type => T,
+            content_type => AcceptContentType}};
+handle_internal_error(method_not_allowed = T) ->
+    {405, #{type => T}};
+handle_internal_error({handler_callback_missing = T, Module, Handler}) ->
+    {501, #{type => T,
+            module => Module,
+            handler => Handler}}.


### PR DESCRIPTION
Sorry, 3 different fixes in single pull-request.

1. Make it possible to set response body as `undefined`, so, it will be empty
2. Fix bug with subsequent calls to cowboy APIs, returning updated `Req` state each time (was ignored til now and this caused major problems with request body larger than ~1200b)
3. Make it possible to handle sheep's internal errors